### PR TITLE
Add test script for reading five load cells

### DIFF
--- a/test_read_five_load_cells.py
+++ b/test_read_five_load_cells.py
@@ -1,0 +1,46 @@
+import argparse
+from IO_master import IO_master
+from devices.AL2205_Hub import AL2205Hub
+from devices.LoadCell_LCM300 import LoadCellLCM300
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read force data from five load cells on an AL2205 hub"
+    )
+    parser.add_argument(
+        "ip",
+        help="IP address of the AL1342 IO master",
+    )
+    parser.add_argument(
+        "--hub-port",
+        type=int,
+        default=1,
+        help="AL1342 port number where the AL2205 hub is connected (1-8)",
+    )
+    parser.add_argument(
+        "--unit",
+        choices=["lbf", "N"],
+        default="N",
+        help="Force units to display",
+    )
+    args = parser.parse_args()
+
+    io = IO_master(args.ip)
+    hub = AL2205Hub(io, port_number=args.hub_port)
+
+    cells = [LoadCellLCM300(hub, x1_index=i) for i in range(5)]
+
+    label = "N" if args.unit.lower() == "n" else "lbf"
+    for i, cell in enumerate(cells, start=1):
+        force = cell.read_force(args.unit)
+        if force is None:
+            print(f"load cell {i}: N/A")
+        else:
+            print(f"load cell {i}: {force:.2f}{label}")
+
+    io.close_client()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test_read_five_load_cells.py` script to read forces from load cells connected to AL2205 hub on ports X1.0–X1.4

## Testing
- `python test_read_five_load_cells.py 192.168.0.10 --unit N`
- `python -m py_compile test_read_five_load_cells.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef6285e3c8332b1a4f75d03f550e3