### PR TITLE
Set default AL1342 IP and clarify AL2205 connection

### DIFF
--- a/IO_master.py
+++ b/IO_master.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
 
 
 class IO_master:
-    def __init__(self, IP_ADDR, SERVER_PORT=502, timeout=1.0):
+    def __init__(self, IP_ADDR="192.168.100.1", SERVER_PORT=502, timeout=1.0):
         self._IP_ADDR = IP_ADDR
         self.SERVER_PORT = SERVER_PORT
         self.timeout = timeout

--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ pip install pyModbusTCP
 ```
 
 ## Example
+By default, `IO_master` uses the AL1342's IP address `192.168.100.1`. The
+example below assumes the AL2205 hub is connected to port 1 and the load cell
+is on channel X1.0.
 
 ```python
 from IO_master import IO_master
 from devices.AL2205_Hub import AL2205Hub
 from devices.LoadCell_LCM300 import LoadCellLCM300
 
-io = IO_master("192.168.0.10")           # IP address of the AL1342
+io = IO_master()                          # Defaults to IP 192.168.100.1
 hub = AL2205Hub(io, port_number=1)        # Hub connected to port 1
 cell = LoadCellLCM300(hub, x1_index=0)    # Load cell on channel X1.0
 


### PR DESCRIPTION
## Summary
- Default the IO_master IP address to the AL1342's standard `192.168.100.1`.
- Update documentation to note the default address and that the AL2205 is connected to port 1/X1.0.

## Testing
- `python -m py_compile IO_master.py devices/AL2205_Hub.py devices/LoadCell_LCM300.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf07dfe3548332b662a7149d8a4296