### PR TITLE
Add GUI monitor for load cells

### DIFF
--- a/read_load_cells.py
+++ b/read_load_cells.py
@@ -2,6 +2,8 @@ from IO_master import IO_master
 from AL2205_Hub import AL2205Hub
 from LoadCell_LCM300 import LoadCellLCM300
 import atexit
+import threading
+import tkinter as tk
 
 # Configure IO master and AL2205 hub
 io = IO_master("192.168.1.1")
@@ -29,3 +31,45 @@ def readLC(n):
         print(f"LC{n}: N/A")
     else:
         print(f"LC{n}: {force:.2f} N")
+
+
+def Open_Monitor():
+    """Open a window that continually displays force readings for all load cells."""
+
+    window = tk.Tk()
+    window.title("Load Cell Monitor")
+
+    labels = []
+    stop_events = []
+
+    for i in range(len(cells)):
+        var = tk.StringVar(value=f"LC{i + 1}: --- N")
+        label = tk.Label(window, textvariable=var)
+        label.pack()
+        labels.append(var)
+
+        stop_event = threading.Event()
+        stop_events.append(stop_event)
+
+        def make_callback(idx):
+            def _update(force):
+                if force is None:
+                    labels[idx].set(f"LC{idx + 1}: N/A")
+                else:
+                    labels[idx].set(f"LC{idx + 1}: {force:.2f} N")
+            return _update
+
+        thread = threading.Thread(
+            target=cells[i].monitor_force,
+            kwargs={"callback": make_callback(i), "stop_event": stop_event},
+            daemon=True,
+        )
+        thread.start()
+
+    def on_close():
+        for ev in stop_events:
+            ev.set()
+        window.destroy()
+
+    window.protocol("WM_DELETE_WINDOW", on_close)
+    window.mainloop()


### PR DESCRIPTION
## Summary
- extend `LoadCellLCM300.monitor_force` with optional callback and stop event for flexible monitoring
- add `Open_Monitor` command to display live readings from five load cells in a Tkinter window

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf458206d08332908533bf7deb88fe