### PR TITLE
Prime IO master register on startup

### DIFF
--- a/read_load_cells.py
+++ b/read_load_cells.py
@@ -7,6 +7,10 @@ import tkinter as tk
 
 # Configure IO master and AL2205 hub
 io = IO_master("192.168.1.1")
+try:
+    io.prime(addr=1008, count=1)
+except Exception:
+    pass
 hub = AL2205Hub(io, port_number=1)
 
 # Instantiate five load cells on ports X1.0 to X1.4


### PR DESCRIPTION
## Summary
- prime the IO master on startup using safe register 1008 to avoid first measurement issues

## Testing
- `python -m py_compile read_load_cells.py`
- `python test_read_five_load_cells.py 192.168.1.1` *(fails: LoadCellLCM300.read_force() takes 1 positional argument but 2 were given)*

------
https://chatgpt.com/codex/tasks/task_e_68bf46d720d083328017ad43b6a6d1cc