### PR TITLE
Remove duplicate read_holding implementation

### DIFF
--- a/IO_master.py
+++ b/IO_master.py
@@ -140,14 +140,3 @@ class IO_master:
             raise ConnectionError(f"Failed to write to register {register}")
         return success
 
-    def read_holding(self, register, count=1, retries=3, delay=0.15):
-        """Read holding registers with retry logic."""
-        for attempt in range(retries):
-            regs = self.client.read_holding_registers(register, count)
-            if regs:
-                return regs
-            time.sleep(delay)
-        raise ConnectionError(
-            f"Failed to read holding registers at {register} after {retries} attempts"
-        )
-


### PR DESCRIPTION
## Summary
- Remove stray second `read_holding` definition from IO_master
- Retain connection-aware read_holding and verify call sites use addr/count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf4b81fef883328b54e680dbe404dc