### PR TITLE
Add optional unit conversion for load cell readings

### DIFF
--- a/LoadCell_LCM300.py
+++ b/LoadCell_LCM300.py
@@ -26,12 +26,20 @@ class LoadCellLCM300:
         raw = self.read_raw_data()
         return raw / 1000 if raw is not None else None
 
-    def read_force(self):
-        """Return the current force measurement in newtons."""
+    def read_force(self, unit="N"):
+        """Return the current force measurement.
+
+        Parameters
+        ----------
+        unit : {"N", "lbf"}, optional
+            Unit for the returned force.  Defaults to newtons (``"N"``).
+        """
         voltage = self.read_voltage()
         if voltage is None:
             return None
         force_lbf = (5.0 - voltage) * 5
+        if unit.lower() == "lbf":
+            return force_lbf
         return force_lbf * 4.44822
 
     def monitor_force(self, duration=None, callback=None, stop_event=None):

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ io = IO_master()                          # Defaults to IP 192.168.100.1
 hub = AL2205Hub(io, port_number=1)        # Hub connected to port 1
 cell = LoadCellLCM300(hub, x1_index=0)    # Load cell on channel X1.0
 
-print(cell.read_force("N"))              # Read force in newtons
+print(cell.read_force())                  # Read force in newtons (default)
+print(cell.read_force("lbf"))             # Read force in pounds-force
 ```
 
 To read up to five load cells from the command line:


### PR DESCRIPTION
## Summary
- allow `LoadCellLCM300.read_force` to return measurements in newtons or pounds-force
- document optional unit argument and provide example usage

## Testing
- `python -m py_compile LoadCell_LCM300.py`
- `python -m py_compile test_read_five_load_cells.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf4da6b74083328ad6700934380ddd