### PR TITLE
Fix AL2205 X1.0 register offset

### DIFF
--- a/AL2205_Hub.py
+++ b/AL2205_Hub.py
@@ -29,8 +29,11 @@ class AL2205Hub:
         count : int, optional
             Number of consecutive registers to read starting at the index.
         """
+        # Per the AL2205 documentation, the first two words following the
+        # base register contain hub‑level diagnostics.  Actual channel data for
+        # X1.0 begins at offset 3 and subsequent channels increment by one.
         word_map = {
-            0: 1,
+            0: 3,
             1: 4,
             2: 5,
             3: 6,


### PR DESCRIPTION
## Summary
- correct register offset for X1.0 per AL2205 documentation and document rationale

## Testing
- `python test_read_five_load_cells.py 192.168.1.1 --cell 1`

------
https://chatgpt.com/codex/tasks/task_e_68bf51330a9c8332987610669b5d8f05