### PR TITLE
Allow readLC to read multiple cells

### DIFF
--- a/Iris_EOL_Sensor_Commands.py
+++ b/Iris_EOL_Sensor_Commands.py
@@ -31,22 +31,26 @@ sd6020_sensor = FlowSensorSD6020(io, port_number=3)
 # Ensure Modbus client is closed on exit
 atexit.register(io.close_client)
 
-
-def readLC(n):
-    """Print the force from load cell ``n`` in newtons.
+def readLC(*nums):
+    """Print the force from one or more load cells in newtons.
 
     Parameters
     ----------
-    n : int
-        Load cell number (1-5).
+    *nums : int
+        One or more load cell numbers (1-5).  Reads all cells when omitted.
     """
-    if not 1 <= n <= len(cells):
-        raise ValueError("Load cell number must be between 1 and 5")
-    force = cells[n - 1].read_force()
-    if force is None:
-        print(f"LC{n}: N/A")
-    else:
-        print(f"LC{n}: {force:.2f} N")
+
+    if not nums:
+        nums = range(1, len(cells) + 1)
+
+    for n in nums:
+        if not 1 <= n <= len(cells):
+            raise ValueError("Load cell number must be between 1 and 5")
+        force = cells[n - 1].read_force()
+        if force is None:
+            print(f"LC{n}: N/A")
+        else:
+            print(f"LC{n}: {force:.2f} N")
 
 
 def readPS():

--- a/test_readLC_multiple.py
+++ b/test_readLC_multiple.py
@@ -1,0 +1,51 @@
+import types
+import sys
+import importlib
+
+class DummyIO:
+    def __init__(self, ip):
+        pass
+    def prime(self, addr=1008, count=1):
+        pass
+    def close_client(self):
+        pass
+
+class DummyHub:
+    def __init__(self, io, port_number):
+        pass
+
+class DummyLoadCell:
+    def __init__(self, hub, x1_index):
+        self.index = x1_index
+    def read_force(self):
+        return 10.0 * (self.index + 1)
+
+class DummyPressure:
+    def __init__(self, hub, x1_index):
+        pass
+
+class DummyFlowPressure:
+    def __init__(self, io, port_number):
+        pass
+
+class DummyFlow:
+    def __init__(self, io, port_number):
+        pass
+
+sys.modules['IO_master'] = types.SimpleNamespace(IO_master=DummyIO)
+sys.modules['AL2205_Hub'] = types.SimpleNamespace(AL2205Hub=DummyHub)
+sys.modules['LoadCell_LCM300'] = types.SimpleNamespace(LoadCellLCM300=DummyLoadCell)
+sys.modules['PressureSensor_PQ3834'] = types.SimpleNamespace(PressureSensorPQ3834=DummyPressure)
+sys.modules['FlowPressure_SD9500'] = types.SimpleNamespace(FlowPressureSensorSD9500=DummyFlowPressure)
+sys.modules['FlowSensor_SD6020'] = types.SimpleNamespace(FlowSensorSD6020=DummyFlow)
+
+cmds = importlib.import_module('Iris_EOL_Sensor_Commands')
+
+def test_read_multiple_cells(capsys):
+    cmds.readLC(1,2,3)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == [
+        'LC1: 10.00 N',
+        'LC2: 20.00 N',
+        'LC3: 30.00 N',
+    ]


### PR DESCRIPTION
## Summary
- Expand `readLC` to accept multiple load-cell numbers or default to all cells.
- Add unit test for reading several load cells in one call.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c337ade28883328560aa230b4f1a89